### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,9 @@ jobs:
             SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
         steps:
             - name: CHECKOUT CODE
-              uses: actions/checkout@v3
+              uses: actions/checkout@v3.1.0
             - name: SETUP PYTHON
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4.3.0
               with:
                   python-version: ${{ matrix.config.py }}
             - name: Install dependencies

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,12 +7,12 @@ jobs:
       OS: ubuntu-latest
       PYTHON: '3.9'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.1.0
       with:
         fetch-depth: ‘2’
 
     - name: Setup Python
-      uses: actions/setup-python@master
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: 3.7
     - name: Generate Report
@@ -21,4 +21,4 @@ jobs:
         pip install --user -r requirements_dev.txt
         coverage run -m unittest
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,8 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v3
+            - uses: actions/checkout@v3.1.0
+            - uses: actions/setup-python@v4.3.0
               with:
                   python-version: 3.8
             - name: Install dependencies

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.1.0
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ENRIC_GAVA }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1)** on 2022-09-19T15:25:54Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.3.0](https://github.com/actions/setup-python/releases/tag/v4.3.0)** on 2022-10-10T11:36:21Z
