### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             - name: CHECKOUT CODE
               uses: actions/checkout@v3.1.0
             - name: SETUP PYTHON
-              uses: actions/setup-python@v4.3.0
+              uses: actions/setup-python@v4.3.1
               with:
                   python-version: ${{ matrix.config.py }}
             - name: Install dependencies

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,7 +12,7 @@ jobs:
         fetch-depth: ‘2’
 
     - name: Setup Python
-      uses: actions/setup-python@v4.3.0
+      uses: actions/setup-python@v4.3.1
       with:
         python-version: 3.7
     - name: Generate Report

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.1.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3.1.0
-            - uses: actions/setup-python@v4.3.0
+            - uses: actions/setup-python@v4.3.1
               with:
                   python-version: 3.8
             - name: Install dependencies

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3.1.0
     - name: Set up Python
-      uses: actions/setup-python@v4.3.0
+      uses: actions/setup-python@v4.3.1
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.3.1](https://github.com/actions/setup-python/releases/tag/v4.3.1)** on 2022-12-08T12:23:19Z
